### PR TITLE
added devtype on device creation

### DIFF
--- a/sp2.py
+++ b/sp2.py
@@ -5,7 +5,7 @@ macaddr = sys.argv[2]
 state = sys.argv[3]
 
 try:
-	device = broadlink.sp2(host=(ip,80), mac=bytearray.fromhex(macaddr))
+	device = broadlink.sp2(host=(ip,80), mac=bytearray.fromhex(macaddr), devtype=0x2711)
 	device.auth()
 	time.sleep(3)
 	device.host


### PR DESCRIPTION
Seems like broadlink changed the number of arguments for the "sp2" class in [this commit](https://github.com/mjg59/python-broadlink/commit/8754493951b887e850d93100898d6883443b124f#diff-8651c630cb85a737f3c4c67091ea485f).

Added devtype for SP2. Else broadlink.sp2 will fail and exception handling jumps in.